### PR TITLE
Remove relative path

### DIFF
--- a/fixtures/one.xml
+++ b/fixtures/one.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">    <url>
-        <loc>fixtures/one/index.html</loc>
+        <loc>http://www.example.com/index.html</loc>
     </url></urlset>

--- a/fixtures/two-ignore.xml
+++ b/fixtures/two-ignore.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">    <url>
-        <loc>fixtures/two/index.html</loc>
+        <loc>http://www.example.com/index.html</loc>
     </url>    <url>
-        <loc>fixtures/two/two.html</loc>
+        <loc>http://www.example.com/two.html</loc>
     </url></urlset>

--- a/fixtures/two.xml
+++ b/fixtures/two.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">    <url>
-        <loc>fixtures/two/index.html</loc>
+        <loc>http://www.example.com/index.html</loc>
     </url>    <url>
-        <loc>fixtures/two/two.html</loc>
+        <loc>http://www.example.com/two.html</loc>
     </url></urlset>

--- a/index.js
+++ b/index.js
@@ -65,5 +65,8 @@ module.exports = function(stream, o) {
 
   finder.on('end', function() {
       stream.write('</urlset>\n');
+      if (stream !== process.stdout) {
+        stream.end();
+      }
   });
 };

--- a/index.js
+++ b/index.js
@@ -55,9 +55,11 @@ module.exports = function(stream, o) {
           if (file.match(ignore_folders[i])) return;
       }
 
-      stream.write(indent(1) + '<url>\n' + indent(2) +
-        '<loc>' + path.join(prefix, path.relative(o.findRoot, file)) + '</loc>\n' +
-        indent(1) + '</url>');
+      stream.write(
+        indent(1) + '<url>\n' +
+        indent(2) + '<loc>' + prefix + path.relative(o.findRoot, file) + '</loc>\n' +
+        indent(1) + '</url>'
+      );
 
   });
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var findit = require('findit');
+var path = require('path');
 
 var header = '<?xml version="1.0" encoding="UTF-8"?>\n' +
   '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
@@ -55,7 +56,7 @@ module.exports = function(stream, o) {
       }
 
       stream.write(indent(1) + '<url>\n' + indent(2) +
-        '<loc>' + prefix + file + '</loc>\n' +
+        '<loc>' + path.join(prefix, path.relative(o.findRoot, file)) + '</loc>\n' +
         indent(1) + '</url>');
 
   });

--- a/test.js
+++ b/test.js
@@ -11,7 +11,8 @@ test('sitemap - one', function(t) {
     t.equal(res, fs.readFileSync('fixtures/one.xml', 'utf8'));
     t.end();
   }), {
-    findRoot: 'fixtures/one'
+    findRoot: 'fixtures/one',
+    prefix: 'http://www.example.com/'
   });
 });
 
@@ -23,7 +24,8 @@ test('sitemap - two', function(t) {
     t.equal(res, fs.readFileSync('fixtures/two.xml', 'utf8'));
     t.end();
   }), {
-    findRoot: 'fixtures/two/'
+    findRoot: 'fixtures/two/',
+    prefix: 'http://www.example.com/'
   });
 });
 
@@ -36,6 +38,7 @@ test('sitemap - two - ignore', function(t) {
     t.end();
   }), {
     findRoot: 'fixtures/two',
-    ignoreFile: 'fixtures/ignore.json'
+    ignoreFile: 'fixtures/ignore.json',
+    prefix: 'http://www.example.com/'
   });
 });


### PR DESCRIPTION
Hi there, I use `sitemap-static` to build a sitemap for my static site, as part of my build process. The build process outputs the site to a folder named `public/`. Originally, `sitemap-static` was inserting `/public/` into all the paths in `sitemap.xml`, which is obviously incorrect because `public/` is simply the folder to hold the build output, and not part of the internet URL.

This patch fixes that by taking the root folder which is passed to this module _out of_ the URLs printed in the output. I also got the tests passing. If this breaks your use case, please let me know and I'll publish this as a separate package on npm (with full credit to you as the original author) (if that's ok!). Or we could add a CLI option to turn this new feature on or off.

Thanks so much!