### PR TITLE
Add pretty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ var generateSitemap = require('sitemap-static');
 generateSitemap({
     findRoot: '.',
     ignoreFile: '',
-    prefix: 'http://somesi.te/'
+    prefix: 'http://somesi.te/',
+    pretty: false
 }, function(err, data) {
     if(err) {
         return console.error(err);

--- a/README.md
+++ b/README.md
@@ -50,3 +50,18 @@ Example JSON:
 Example Command:
 
 	sitemap-static --ignore-file=ignore.json --prefix=http://foo.bar/foo/ . > sitemap.xml
+
+## Pretty URLs
+
+If you pass `--pretty=true` to the CLI (or `pretty: true` to the JS API), `sitemap-static` will output pretty URLs rather than the whole path to each file. For example:
+
+| Not pretty | Pretty |
+| --- | --- |
+| `http://www.example.com/index.html` | `http://www.example.com/` |
+| `http://www.example.com/about.html` | `http://www.example.com/about` |
+| `http://www.example.com/author/index.html` | `http://www.example.com/author` |
+| `http://www.example.com/author/main.html` | `http://www.example.com/author/main` |
+
+Example Command:
+
+	sitemap-static --prefix=http://foo.bar/foo/ --pretty=true . > sitemap.xml

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Example Command:
 
 ## Pretty URLs
 
-If you pass `--pretty=true` to the CLI (or `pretty: true` to the JS API), `sitemap-static` will output pretty URLs rather than the whole path to each file. For example:
+If you pass `--pretty` to the CLI (or `pretty: true` to the JS API), `sitemap-static` will output pretty URLs rather than the whole path to each file. For example:
 
 | Not pretty | Pretty |
 | --- | --- |
@@ -64,4 +64,4 @@ If you pass `--pretty=true` to the CLI (or `pretty: true` to the JS API), `sitem
 
 Example Command:
 
-	sitemap-static --prefix=http://foo.bar/foo/ --pretty=true . > sitemap.xml
+	sitemap-static --prefix=http://foo.bar/foo/ --pretty . > sitemap.xml

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 
-var argv = require('minimist')(process.argv.slice(2)),
-    generateSitemap = require('../');
+var argv = require('minimist')(
+  process.argv.slice(2),
+  {
+    'boolean': 'pretty'
+  }
+);
+
+var generateSitemap = require('../');
 
 
 var prefix = argv.prefix;

--- a/bin/index.js
+++ b/bin/index.js
@@ -17,4 +17,5 @@ generateSitemap(process.stdout, {
     findRoot: argv._[0] || '.',
     ignoreFile: argv['ignore-file'],
     prefix: prefix,
+    pretty: argv.pretty,
 });

--- a/fixtures/three.xml
+++ b/fixtures/three.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">    <url>
+        <loc>http://www.example.com/about</loc>
+    </url>    <url>
+        <loc>http://www.example.com/</loc>
+    </url>    <url>
+        <loc>http://www.example.com/author</loc>
+    </url>    <url>
+        <loc>http://www.example.com/author/main</loc>
+    </url></urlset>

--- a/fixtures/three/about.html
+++ b/fixtures/three/about.html
@@ -1,0 +1,1 @@
+hello world

--- a/fixtures/three/author/index.html
+++ b/fixtures/three/author/index.html
@@ -1,0 +1,1 @@
+hello world

--- a/fixtures/three/index.html
+++ b/fixtures/three/index.html
@@ -1,0 +1,1 @@
+hello world

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = function(stream, o) {
 
   var prefix = o.prefix || '';
   var ignore_file = o.ignoreFile || '';
+  var pretty = o.pretty || false;
   var ignore = [];
   var ignore_folders = [];
 
@@ -55,9 +56,23 @@ module.exports = function(stream, o) {
           if (file.match(ignore_folders[i])) return;
       }
 
+      var filepath = path.relative(o.findRoot, file);
+
+      if (pretty) {
+        if (path.basename(filepath) === 'index.html') {
+          var dir = path.dirname(filepath);
+          filepath = dir === '.' ? '' : dir;
+        } else {
+          filepath = path.join(
+            path.dirname(filepath),
+            path.basename(filepath, '.html')
+          );
+        }
+      }
+
       stream.write(
         indent(1) + '<url>\n' +
-        indent(2) + '<loc>' + prefix + path.relative(o.findRoot, file) + '</loc>\n' +
+        indent(2) + '<loc>' + prefix + filepath + '</loc>\n' +
         indent(1) + '</url>'
       );
 

--- a/test.js
+++ b/test.js
@@ -42,3 +42,17 @@ test('sitemap - two - ignore', function(t) {
     prefix: 'http://www.example.com/'
   });
 });
+
+test('sitemap - three', function(t) {
+  sitemap(concat(function(res) {
+    if (process.env.UPDATE) {
+      fs.writeFileSync('fixtures/three.xml', res);
+    }
+    t.equal(res, fs.readFileSync('fixtures/three.xml', 'utf8'));
+    t.end();
+  }), {
+    findRoot: 'fixtures/three/',
+    prefix: 'http://www.example.com/',
+    pretty: true
+  });
+});


### PR DESCRIPTION
Hey, another PR! My site uses pretty URLs, so `www.example.com/author/index.html` becomes `www.example.com/author`. This PR adds a `--pretty` option to remove `index.html` from the output. It also means that `www.example.com/about.html` becomes `www.example.com/about`, because a lot of static site frameworks (e.g. [Netlify](https://www.netlify.com/docs/redirects/#trailing-slash)) feature this kind of URL rewrite.