### PR TITLE
Cleanup output format and fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ files with `.html` extensions to the sitemap.
 
 ```javascript
 var generateSitemap = require('sitemap-static');
+var fs = require('fs');
 
-generateSitemap({
+var writer = fs.createWriteStream('/path/to/your/sitemap.xml');
+
+generateSitemap(writer, {
     findRoot: '.',
     ignoreFile: '',
     prefix: 'http://somesi.te/',

--- a/fixtures/one.xml
+++ b/fixtures/one.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">    <url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
         <loc>http://www.example.com/index.html</loc>
-    </url></urlset>
+    </url>
+</urlset>

--- a/fixtures/three.xml
+++ b/fixtures/three.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">    <url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
         <loc>http://www.example.com/about</loc>
-    </url>    <url>
+    </url>
+    <url>
         <loc>http://www.example.com/</loc>
-    </url>    <url>
+    </url>
+    <url>
         <loc>http://www.example.com/author</loc>
-    </url>    <url>
+    </url>
+    <url>
         <loc>http://www.example.com/author/main</loc>
-    </url></urlset>
+    </url>
+</urlset>

--- a/fixtures/two-ignore.xml
+++ b/fixtures/two-ignore.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">    <url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
         <loc>http://www.example.com/index.html</loc>
-    </url>    <url>
+    </url>
+    <url>
         <loc>http://www.example.com/two.html</loc>
-    </url></urlset>
+    </url>
+</urlset>

--- a/fixtures/two.xml
+++ b/fixtures/two.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">    <url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
         <loc>http://www.example.com/index.html</loc>
-    </url>    <url>
+    </url>
+    <url>
         <loc>http://www.example.com/two.html</loc>
-    </url></urlset>
+    </url>
+</urlset>

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ module.exports = function(stream, o) {
       }
 
       stream.write(
+        '\n' +
         indent(1) + '<url>\n' +
         indent(2) + '<loc>' + prefix + filepath + '</loc>\n' +
         indent(1) + '</url>'
@@ -79,7 +80,7 @@ module.exports = function(stream, o) {
   });
 
   finder.on('end', function() {
-      stream.write('</urlset>\n');
+      stream.write('\n</urlset>\n');
       if (stream !== process.stdout) {
         stream.end();
       }


### PR DESCRIPTION
I think the README forgets to mention the first argument, a writeable stream.

I also adjusted the output format slightly so it's easier to read & double-check.