### PR TITLE
docs(readme): Remove the callback in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,6 @@ generateSitemap(writer, {
     ignoreFile: '',
     prefix: 'http://somesi.te/',
     pretty: false
-}, function(err, data) {
-    if(err) {
-        return console.error(err);
-    }
-
-    // xml sitemap
-    console.log(data);
 })
 ```
 


### PR DESCRIPTION
:wave: Hello!

The exposed function doesn't accept a callback, so this PR removes the callback example from the documentation.