### PR TITLE
Add trailing slash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ generateSitemap(writer, {
     findRoot: '.',
     ignoreFile: '',
     prefix: 'http://somesi.te/',
-    pretty: false
+    pretty: false,
+    trailingSlash: false
 })
 ```
 
@@ -62,3 +63,11 @@ If you pass `--pretty` to the CLI (or `pretty: true` to the JS API), `sitemap-st
 Example Command:
 
 	sitemap-static --prefix=http://foo.bar/foo/ --pretty . > sitemap.xml
+
+## Trailing slashes
+
+If you pass `--trailing-slash` to the CLI (or `trailingSlash: true` to the JS API) _and_ the `pretty` option is true, `sitemap-static` will output URLs with a trailing slash
+
+Example Command:
+
+	sitemap-static --prefix=http://foo.bar/foo/ --pretty --trailing-slash . > sitemap.xml

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 const argv = require("minimist")(process.argv.slice(2), {
-  boolean: "pretty"
+  boolean: "pretty",
+  boolean: "trailing-slash"
 });
 
 const generateSitemap = require("./");
@@ -20,5 +21,6 @@ generateSitemap(process.stdout, {
   findRoot: argv._[0] || ".",
   ignoreFile: argv["ignore-file"],
   prefix: prefix,
-  pretty: argv.pretty
+  pretty: argv.pretty,
+  trailingSlash: argv["trailing-slash"]
 });

--- a/fixtures/four.xml
+++ b/fixtures/four.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>http://www.example.com/about/</loc>
+    </url>
+    <url>
+        <loc>http://www.example.com/</loc>
+    </url>
+    <url>
+        <loc>http://www.example.com/author/</loc>
+    </url>
+    <url>
+        <loc>http://www.example.com/author/main/</loc>
+    </url>
+</urlset>

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = function(stream, o = {}) {
   const prefix = o.prefix || "";
   const ignore_file = o.ignoreFile || "";
   const pretty = o.pretty || false;
+  const trailingSlash = o.trailingSlash || false;
   let ignore_folders = [];
   let ignore = [];
 
@@ -56,6 +57,10 @@ module.exports = function(stream, o = {}) {
           path.dirname(filepath),
           path.basename(filepath, ".html")
         );
+      }
+
+      if (trailingSlash && dir !== ".") {
+        filepath = filepath + "/";
       }
     }
 

--- a/test.js
+++ b/test.js
@@ -56,3 +56,18 @@ test('sitemap - three', function(t) {
     pretty: true
   });
 });
+
+test('sitemap - four', function(t) {
+  sitemap(concat(function(res) {
+    if (process.env.UPDATE) {
+      fs.writeFileSync('fixtures/four.xml', res);
+    }
+    t.equal(res, fs.readFileSync('fixtures/four.xml', 'utf8'));
+    t.end();
+  }), {
+    findRoot: 'fixtures/three/',
+    prefix: 'http://www.example.com/',
+    pretty: true,
+    trailingSlash: true
+  });
+});


### PR DESCRIPTION
This PR adds a `trailingSlash` option to configure URLs to have trailing slashes when `pretty` is true.

cc. @tmcw 